### PR TITLE
Update project-structure.json to allow CSS modules for now

### DIFF
--- a/project-structure.json
+++ b/project-structure.json
@@ -33,6 +33,10 @@
 									{
 										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
 										"extension": ["tsx", "ts"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(module))?$/",
+										"extension": ["css"]
 									}
 								]
                             }
@@ -51,6 +55,10 @@
 									{
 										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
 										"extension": ["tsx", "ts"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(module))?$/",
+										"extension": ["css"]
 									}
 								]
                             }


### PR DESCRIPTION
Allow [CSS modules](https://github.com/css-modules/css-modules) to be used for now (instead of only styled components being allowed) so we can get Brade's PR through more easily. Migrating to Styled Components can come later.

This change expects `ComponentName.module.css` / `RouteName.module.css` within the matching component/route folder.

Note: This is a quick patch that I honestly haven't fully tested. Happy for fixes to it to be included in Brade's PR branch (or any other PR branch that it's relevant to). 