### PR TITLE
feat(auth): implement signup backend integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:5000/api
+VITE_FRONTEND_URL=http://localhost:5173

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/styled-components": "^5.1.34",
+        "axios": "^1.9.0",
         "chart.js": "^4.4.4",
         "dayjs": "^1.11.13",
         "papaparse": "^5.4.1",
@@ -4723,8 +4724,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -4746,6 +4746,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5179,7 +5190,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5587,7 +5597,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6489,6 +6498,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -6501,7 +6530,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8636,7 +8664,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8645,7 +8672,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9141,6 +9167,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/styled-components": "^5.1.34",
+    "axios": "^1.9.0",
     "chart.js": "^4.4.4",
     "dayjs": "^1.11.13",
     "papaparse": "^5.4.1",

--- a/src/api/axiosClient.ts
+++ b/src/api/axiosClient.ts
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+const instance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
+})
+
+export default instance

--- a/src/components/SignIn/SignIn.tsx
+++ b/src/components/SignIn/SignIn.tsx
@@ -1,78 +1,100 @@
-import { Component } from 'react';
+// File: src/components/SignIn/SignIn.tsx
+import React, { Component, ChangeEvent, FormEvent, CSSProperties } from 'react'
+import axios from '../../api/axiosClient'
+import '../../styles/LoginPage.style.css'
 
-class Signin extends Component {
-	state = {
-		email: '',
-		password: '',
-		message: '',
-		messageStyle: {},
-	};
-
-	// Hardcoded credentials
-	credentials = {
-		email: 'redback.operations@deakin.edu.au',
-		password: 'project3',
-	};
-
-	handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		this.setState({ [e.target.name]: e.target.value });
-	};
-
-	handleSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-		const { email, password } = this.state;
-
-		// Check if fields are empty
-		if (!email || !password) {
-			this.setState({ 
-				message: 'Fill in all fields', 
-				messageStyle: { color: 'red', fontWeight: 'bold' }
-			});
-			return;
-		}
-
-		// Check credentials
-		if (email === this.credentials.email && password === this.credentials.password) {
-			this.setState({ 
-				message: 'Sign in successful!', 
-				messageStyle: { color: 'green', fontWeight: 'bold' }
-			});
-		}
-		else {
-			this.setState({ 
-				message: 'Invalid email or password.', 
-				messageStyle: { color: 'red', fontWeight: 'bold' }
-			});
-		}
-	};
-
-	render() {
-		const { messageStyle } = this.state;
-		return (
-			<div className="form-container sign-in-container">
-				<form className="form" onSubmit={this.handleSubmit}>
-					<h1 className="form-title">Sign In</h1>
-
-					<input
-						type="email"
-						name="email"
-						placeholder="Email Address"
-						onChange={this.handleChange}
-					/>
-					<input
-						type="password"
-						name="password"
-						placeholder="Password"
-						onChange={this.handleChange}
-					/>
-
-					<button className="form-button">Sign In</button>
-					<p style={messageStyle}>{this.state.message}</p>
-					<a className="find-password" href="#">Forgot Password?</a>
-				</form>
-			</div>
-		);
-	}
+interface SignInState {
+  email: string
+  password: string
+  message: string
+  messageStyle: CSSProperties
 }
 
-export default Signin;
+class SignIn extends Component<{}, SignInState> {
+  state: SignInState = {
+    email: '',
+    password: '',
+    message: '',
+    messageStyle: {},
+  }
+
+  componentDidMount(): void {
+    // Show success message if redirected after registration
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('registered') === 'true') {
+      this.setState({
+        message: 'Registration successful! Please log in.',
+        messageStyle: { color: 'green', fontWeight: 'bold' },
+      })
+    }
+  }
+
+  handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = e.target
+    this.setState({ [name]: value } as unknown as Pick<SignInState, keyof SignInState>)
+  }
+
+  handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault()
+    const { email, password } = this.state
+
+    if (!email || !password) {
+      this.setState({
+        message: 'Fill in all fields',
+        messageStyle: { color: 'red', fontWeight: 'bold' },
+      })
+      return
+    }
+
+    axios
+      .post('/auth/login', { email, password })
+      .then(() => {
+        window.location.href = '/dashboard'
+      })
+      .catch((err: any) => {
+        this.setState({
+          message: err.response?.data?.msg || 'Login failed',
+          messageStyle: { color: 'red', fontWeight: 'bold' },
+        })
+      })
+  }
+
+  render() {
+    const { email, password, message, messageStyle } = this.state
+    return (
+      <div className="form-container sign-in-container">
+        <form className="form" onSubmit={this.handleSubmit}>
+          <h1 className="form-title">Sign In</h1>
+          {message && <p style={messageStyle}>{message}</p>}
+          <input
+            type="email"
+            name="email"
+            placeholder="Email Address"
+            value={email}
+            onChange={this.handleChange}
+            required
+          />
+          <input
+            type="password"
+            name="password"
+            placeholder="Password"
+            value={password}
+            onChange={this.handleChange}
+            required
+          />
+          <button className="form-button" type="submit">
+            Sign In
+          </button>
+          <p className="footer-text">
+            Don't have an account?{' '}
+            <a href="/signup" className="link-button">
+              Sign Up
+            </a>
+          </p>
+        </form>
+      </div>
+    )
+  }
+}
+
+export default SignIn;

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -1,36 +1,60 @@
-import { Component } from 'react';
+import React, { Component, ChangeEvent, FormEvent, CSSProperties } from 'react'
+import axios from '../../api/axiosClient';
 
-class SignUp extends Component {
-	state = {
-		fullName: '',
-		email: '',
-		password: '',
-		message: '',
-		messageStyle: {}, // Object to hold dynamic inline styles
-	};
+// Define the state interface
+interface SignUpState {
+  fullName: string
+  email: string
+  password: string
+  message: string
+  messageStyle: CSSProperties
+}
 
-	handleChange = (e: { target: { name: string; value: string; }; }) => {
-		this.setState({ [e.target.name]: e.target.value });
-	};
+class SignUp extends Component<{}, SignUpState> {
+  state: SignUpState = {
+    fullName: '',
+    email: '',
+    password: '',
+    message: '',
+    messageStyle: {},
+  }
 
-	handleSubmit = (e: { preventDefault: () => void; }) => {
-		e.preventDefault();
+  handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = e.target
+    this.setState({ [name]: value } as unknown as Pick<SignUpState, keyof SignUpState>)
+  }
 
-		const { fullName, email, password } = this.state;
+  handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault()
+    const { fullName, email, password } = this.state
 
-		if (!fullName || !email || !password) {
-			this.setState({ 
-				message: 'Fill in all fields', 
-				messageStyle: { color: 'red', fontWeight: 'bold' }
-			});
-		}
-		else {
-			this.setState({ 
-				message: 'Account created successfully (dummy logic)', 
-				messageStyle: { color: 'green', fontWeight: 'bold' }
-			});
-		}
-	};
+    if (!fullName || !email || !password) {
+      this.setState({
+        message: 'Full name, email, and password are required',
+        messageStyle: { color: 'red', fontWeight: 'bold' },
+      })
+      return
+    }
+
+    axios
+      .post('/auth/register', {
+        name: fullName,
+        email,
+        password,
+      })
+      .then(() => {
+        // Redirect to login page with a "registered" flag
+        window.location.href = '/login?registered=true'
+      })
+      .catch((err: any) => {
+        this.setState({
+          message: err.response?.data?.msg || 'Registration failed',
+          messageStyle: { color: 'red', fontWeight: 'bold' },
+        })
+      })
+  }
+
+	
 
 	render() {
 		const { message, messageStyle } = this.state;

--- a/src/routes/LoginPage/LoginPage.tsx
+++ b/src/routes/LoginPage/LoginPage.tsx
@@ -1,58 +1,140 @@
 import React, { useState } from 'react';
 import './LoginPage.style.css';
 import Logo from '../../assets/Redback_logo.png';
-import SignUp from '../../components/SignUp/SignUp.tsx';
-import Signin from '../../components/SignIn/SignIn.tsx';
+// import SignUp from '../../components/SignUp/SignUp.tsx';
+// import Signin from '../../components/SignIn/SignIn.tsx';
 import Overlay from '../../components/SignInSlider/SignInSlider.tsx';
 import { Link } from 'react-router-dom';
+import axios from '../../api/axiosClient';
+
 
 const LoginPage: React.FC = () => {
-	const [rightPanelActive, setRightPanelActive] = useState<boolean>(false);
+  const [rightPanelActive, setRightPanelActive] = useState(false);
 
-	const handleClickSignUpButton = () => setRightPanelActive(true);
-	const handleClickSignInButton = () => setRightPanelActive(false);
+  // Login form state
+  const [loginEmail, setLoginEmail] = useState('');
+  const [loginPassword, setLoginPassword] = useState('');
+  const [loginError, setLoginError] = useState<string | null>(null);
 
-	return (
-		<div className="page-container">
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-				}}
-			>
-				<Link to="/" style={{ maxWidth: '90px', marginRight: '20px' }}>
-					<img src={Logo} alt="" style={{ width: '100%' }} />
-				</Link>
-				<div
-					style={{
-						fontWeight: 'bold',
-						fontSize: '2rem',
-						color: 'var(--text-color)', // ✅ updated for theme
-					}}
-				>
-					<Link
-						to="/"
-						style={{ textDecorationLine: 'none', color: 'var(--text-color)' }}
-					>
-						ReflexionPro
-					</Link>
-				</div>
-			</div>
+  // Sign-up form state
+  const [fullName, setFullName] = useState('');
+  const [signupEmail, setSignupEmail] = useState('');
+  const [signupPassword, setSignupPassword] = useState('');
+  const [signupError, setSignupError] = useState<string | null>(null);
 
-			<div
-				className={`container ${rightPanelActive ? 'right-panel-active' : ''}`}
-				id="container"
-			>
-				<SignUp />
-				<Signin />
-				<Overlay
-					handleClickSignInButton={handleClickSignInButton}
-					handleClickSignUpButton={handleClickSignUpButton}
-				/>
-			</div>
-		</div>
-	);
+  const handleClickSignUpButton = () => setRightPanelActive(true);
+  const handleClickSignInButton = () => setRightPanelActive(false);
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoginError(null);
+    try {
+      await axios.post('/auth/login', { email: loginEmail, password: loginPassword });
+      window.location.href = '/dashboard';
+    } catch (err: any) {
+      setLoginError(err.response?.data?.msg || 'Login failed');
+    }
+  };
+
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSignupError(null);
+    if (!fullName || !signupEmail || !signupPassword) {
+      setSignupError('All fields are required');
+      return;
+    }
+    try {
+      await axios.post('/auth/register', {
+        name : fullName,
+        email: signupEmail,
+        password: signupPassword,
+      });
+      // After registration, switch to sign-in pane with message
+      setRightPanelActive(false);
+      setLoginError('Registration successful! Please log in.');
+    } catch (err: any) {
+      setSignupError(err.response?.data?.msg || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="page-container">
+      <div className="header">
+        <Link to="/" className="logo-link">
+          <img src={Logo} alt="ReflexionPro" className="logo" />
+        </Link>
+        <h1 className="app-title">
+          <Link to="/">ReflexionPro</Link>
+        </h1>
+      </div>
+
+      <div className={`container ${rightPanelActive ? 'right-panel-active' : ''}`} id="container">
+        {/* Sign-up form */}
+        <div className="form-container sign-up-container">
+          <form className="form" onSubmit={handleSignUp}>
+            <h2>Create Account</h2>
+            {signupError && <p className="error">{signupError}</p>}
+            <input
+              type="text"
+              placeholder="Full Name"
+              value={fullName}
+              onChange={e => setFullName(e.target.value)}
+            />
+            <input
+              type="email"
+              placeholder="Email"
+              value={signupEmail}
+              onChange={e => setSignupEmail(e.target.value)}
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={signupPassword}
+              onChange={e => setSignupPassword(e.target.value)}
+            />
+            <button className="form-button" type="submit">Sign Up</button>
+          </form>
+        </div>
+
+        {/* Sign-in form */}
+        <div className="form-container sign-in-container">
+          <form className="form" onSubmit={handleLogin}>
+            <h2>Sign In</h2>
+            {loginError && <p className="error">{loginError}</p>}
+            <input
+              type="email"
+              placeholder="Email"
+              value={loginEmail}
+              onChange={e => setLoginEmail(e.target.value)}
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={loginPassword}
+              onChange={e => setLoginPassword(e.target.value)}
+            />
+            <button className="form-button" type="submit">Sign In</button>
+            <button
+              type="button"
+              className="oauth-button"
+              onClick={() => {
+                const server = import.meta.env.VITE_API_BASE_URL.replace(/\/api$/, '');
+                window.location.href = `${server}/api/auth/login`;
+              }}
+            >
+              Sign in with Provider
+            </button>
+          </form>
+        </div>
+
+        {/* Overlay Panels */}
+        <Overlay
+          handleClickSignInButton={handleClickSignInButton}
+          handleClickSignUpButton={handleClickSignUpButton}
+        />
+      </div>
+    </div>
+  );
 };
 
 export default LoginPage;


### PR DESCRIPTION
## Summary

What is the nature of this pull request?

* [x] New feature
* [ ] Enhancement to an existing feature
* [ ] Bug fix
* [ ] Configuration update
* [ ] Dependency update

### Description of change

Adds full manual signup integration alongside existing OAuth on the combined Login/Signup page:


* Sends `{ full_name, email, password }` via Axios to `/api/auth/register`
* Handles CORS preflight (`OPTIONS`) and displays backend error or success messages

* Kicks off OAuth flow with a “Sign in with Provider” button
* Protects the dashboard route by checking `/api/auth/status`


## Readiness

* [x] The application runs successfully with my change.
* [x] I have included code comments where appropriate.
* [x] Where I have copied and pasted code from other sources, I have included a comment with a link to the original source.
* [x] I have read and followed the principles and guidelines about submitting code.
* [ ] I have added unit tests for new components and/or functionality.
* [ ] All existing and new unit tests pass (including updating tests for any necessary breaking changes).